### PR TITLE
fix: delay should work on all messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
-
-export default (duration)=>source=>{
-    return (type,sink)=>{
-        if(type !== 0) return
-        source(0,(t,d)=>{
-            if(t !== 1) return sink(t,d)
-            let id = setTimeout(()=>{
-                clearTimeout(id)
-                sink(1,d)
-            },duration)
-        })
-    }
-}
+export default (duration) => (source) => {
+  return (type, sink) => {
+    if (type !== 0) return;
+    source(0, (t, d) => {
+      let id = setTimeout(() => {
+        clearTimeout(id);
+        sink(t, d);
+      }, duration);
+    });
+  };
+};


### PR DESCRIPTION
Delay should work for all messages, not just for pull.

For example:

```js
const src = concat(
  pipe(interval(1000), take(5)),
  pipe(of(""), delay(3000)),
  pipe(interval(1000), take(3))
);

forEach(console.log)(src);
```

The expected output of this program should be like this:

```
0--1--2--3--4--- wait for 3 seconds ---0--1--2
```

However, with the current implementation, I got this:

```
0--1--2--3--4--0--1--- wait for 3 seconds ---2
```

The completion message(2) was not scheduled into the timer.